### PR TITLE
feat: support import statements

### DIFF
--- a/corpus/import.test
+++ b/corpus/import.test
@@ -1,0 +1,50 @@
+==========
+Basic import statement
+==========
+import thing
+
+---
+(source_file
+  (groovy_import
+    (identifier)))
+==========
+Import with alias
+==========
+
+import thing as other_thing
+
+---
+(source_file
+  (groovy_import
+    (identifier)
+    (identifier)))
+==========
+Import with dotted ident
+==========
+import package.subpackage
+
+---
+(source_file
+ (groovy_import
+   (dotted_identifier
+   (identifier)
+   (identifier))))
+==========
+Star import
+==========
+import all_of_the_things.*
+
+---
+(source_file
+ (groovy_import
+   (identifier)))
+==========
+Static import statement
+==========
+import static thing
+
+---
+(source_file
+  (groovy_import
+    (modifier)
+    (identifier)))

--- a/grammar.js
+++ b/grammar.js
@@ -49,6 +49,7 @@ module.exports = grammar({
 
     _statement: $ => prec.left(PREC.STATEMENT, seq(choice(
       $.assertion,
+      $.groovy_import,
       $.assignment,
       $.class_definition,
       $.declaration,
@@ -92,6 +93,21 @@ module.exports = grammar({
     dotted_identifier: $ => seq(
       $.identifier,
       repeat1(seq('.', $.identifier)),
+    ),
+
+    groovy_import: $ => seq(
+      'import',
+      optional($.modifier),
+      field('import',
+          choice(
+            $.identifier,
+            $.dotted_identifier,
+            seq(choice($.identifier, $.dotted_identifier), '.*')
+          )
+      ),
+      optional(
+        seq('as', field('import_alias', $.identifier))
+      )
     ),
 
     _prefix_expression: $ => prec.left(1, choice(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -66,6 +66,10 @@
               },
               {
                 "type": "SYMBOL",
+                "name": "groovy_import"
+              },
+              {
+                "type": "SYMBOL",
                 "name": "assignment"
               },
               {
@@ -308,6 +312,91 @@
               }
             ]
           }
+        }
+      ]
+    },
+    "groovy_import": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "import"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "modifier"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "import",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "dotted_identifier"
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "dotted_identifier"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "STRING",
+                    "value": ".*"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "as"
+                },
+                {
+                  "type": "FIELD",
+                  "name": "import_alias",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -575,6 +575,10 @@
           "named": true
         },
         {
+          "type": "groovy_import",
+          "named": true
+        },
+        {
           "type": "if_statement",
           "named": true
         },
@@ -747,6 +751,10 @@
         },
         {
           "type": "function_definition",
+          "named": true
+        },
+        {
+          "type": "groovy_import",
           "named": true
         },
         {
@@ -1036,6 +1044,10 @@
             "named": true
           },
           {
+            "type": "groovy_import",
+            "named": true
+          },
+          {
             "type": "if_statement",
             "named": true
           },
@@ -1221,6 +1233,10 @@
             "named": true
           },
           {
+            "type": "groovy_import",
+            "named": true
+          },
+          {
             "type": "if_statement",
             "named": true
           },
@@ -1398,6 +1414,10 @@
           },
           {
             "type": "function_definition",
+            "named": true
+          },
+          {
+            "type": "groovy_import",
             "named": true
           },
           {
@@ -1582,6 +1602,10 @@
           },
           {
             "type": "function_definition",
+            "named": true
+          },
+          {
+            "type": "groovy_import",
             "named": true
           },
           {
@@ -2004,6 +2028,50 @@
     }
   },
   {
+    "type": "groovy_import",
+    "named": true,
+    "fields": {
+      "import": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": ".*",
+            "named": false
+          },
+          {
+            "type": "dotted_identifier",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "import_alias": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "modifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "if_statement",
     "named": true,
     "fields": {
@@ -2065,6 +2133,10 @@
           },
           {
             "type": "function_definition",
+            "named": true
+          },
+          {
+            "type": "groovy_import",
             "named": true
           },
           {
@@ -2229,6 +2301,10 @@
           },
           {
             "type": "function_definition",
+            "named": true
+          },
+          {
+            "type": "groovy_import",
             "named": true
           },
           {
@@ -3023,6 +3099,10 @@
           "named": true
         },
         {
+          "type": "groovy_import",
+          "named": true
+        },
+        {
           "type": "if_statement",
           "named": true
         },
@@ -3498,6 +3578,10 @@
             "named": true
           },
           {
+            "type": "groovy_import",
+            "named": true
+          },
+          {
             "type": "if_statement",
             "named": true
           },
@@ -3806,6 +3890,10 @@
             "named": true
           },
           {
+            "type": "groovy_import",
+            "named": true
+          },
+          {
             "type": "if_statement",
             "named": true
           },
@@ -4053,6 +4141,10 @@
   },
   {
     "type": ".&",
+    "named": false
+  },
+  {
+    "type": ".*",
     "named": false
   },
   {
@@ -4317,6 +4409,10 @@
   },
   {
     "type": "if",
+    "named": false
+  },
+  {
+    "type": "import",
     "named": false
   },
   {


### PR DESCRIPTION
Hi! I found this repo through your issue on the [tree-sitter-groovy](https://github.com/Decodetalkers/tree-sitter-groovy) repo. I saw you were open to contributions and I wanted to take a shot at supporting `import` statements. I used [these docs](https://groovy-lang.org/structure.html) as a loose reference. I wasn't super sure where `groovy_import` should go in terms of precedence, but I hope at the very least this might help you get started on implementing the full feature :)

Let me know if there's anything you'd like changed/ worked on, I'd be happy to iterate on this. 