### PR TITLE
Cleanup with closures

### DIFF
--- a/corpus/closure.test
+++ b/corpus/closure.test
@@ -1,0 +1,85 @@
+==========
+Closure with no args, no arrow, function call in body
+==========
+def myClosure = {
+       foo()
+}
+---
+(source_file
+      (declaration
+        (identifier)
+        (closure
+          (function_call
+            (identifier)
+            (argument_list)))))
+
+==========
+Closure with no args, no arrow, integer literal expression in body
+==========
+def myClosure = {
+       1
+}
+---
+(source_file
+      (declaration
+        (identifier)
+        (closure
+            (number_literal))))
+
+==========
+Closure with no args, arrow, function call in body
+==========
+def myClosure = {
+       -> 
+       foo()
+}
+---
+(source_file
+      (declaration
+        (identifier)
+        (closure
+          (function_call
+            (identifier)
+            (argument_list)))))
+
+==========
+Closure with one arg
+==========
+def myClosure = {
+       a -> 
+       y = a
+}
+---
+(source_file
+      (declaration
+        (identifier)
+        (closure
+          (parameter_list
+            (parameter
+              (identifier)))
+          (assignment
+            (identifier)
+            (identifier)))))
+
+==========
+Closure with multiple args
+==========
+def myClosure = {
+       a, b ->
+       y = a + b
+}
+---
+(source_file
+      (declaration
+        (identifier)
+        (closure
+          (parameter_list
+            (parameter
+              (identifier))
+            (parameter
+              (identifier)))
+          (assignment
+            (identifier)
+            (binary_op
+              (identifier)
+              (identifier))))))

--- a/grammar.js
+++ b/grammar.js
@@ -226,7 +226,7 @@ module.exports = grammar({
 
     closure: $ => seq(
       '{',
-      optional(seq($.parameter_list, '->')),
+      optional(choice('->', seq(alias($._param_list, $.parameter_list), '->'))),
       // repeat(choice($._statement, $._expression)),
       repeat($._statement),
       optional($._expression),
@@ -365,6 +365,8 @@ module.exports = grammar({
         ')',
       )),
 
+    _param_list: $ => prec(1, list_of($.parameter)),
+
     parameter_list: $ => prec(1, seq(
       '(',
       optional(list_of($.parameter)),
@@ -372,7 +374,7 @@ module.exports = grammar({
     )),
 
     parameter: $ => seq(
-      field('type', $._type),
+      optional(field('type', $._type)),
       field('name', $.identifier),
       optional(seq('=', field('value', $._expression))),
     ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1624,15 +1624,29 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
+              "type": "CHOICE",
               "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "parameter_list"
-                },
                 {
                   "type": "STRING",
                   "value": "->"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "_param_list"
+                      },
+                      "named": true,
+                      "value": "parameter_list"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "->"
+                    }
+                  ]
                 }
               ]
             },
@@ -2314,6 +2328,56 @@
         ]
       }
     },
+    "_param_list": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "PREC_LEFT",
+              "value": 0,
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "parameter"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "parameter"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
     "parameter_list": {
       "type": "PREC",
       "value": 1,
@@ -2389,12 +2453,20 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "FIELD",
-          "name": "type",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_type"
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "type",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_type"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "FIELD",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2987,7 +2987,7 @@
       },
       "type": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "array_type",


### PR DESCRIPTION
I wrote some relevant test cases and tried to make some small changes to address #3.
- Allowed for parameter lists without parentheses for closures
- Made the `type` field optional for parameters

Hope this helps! :)

Closes #3 