### PR TITLE
feat: Reimplement imports and expose wildcards as a named node

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -7,6 +7,9 @@ fn main() {
         .flag_if_supported("-Wno-unused-parameter")
         .flag_if_supported("-Wno-unused-but-set-variable")
         .flag_if_supported("-Wno-trigraphs");
+    #[cfg(target_env = "msvc")]
+    c_config.flag("-utf-8");
+
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
 

--- a/corpus/import.test
+++ b/corpus/import.test
@@ -6,7 +6,8 @@ import thing
 ---
 (source_file
   (groovy_import
-    (identifier)))
+    import: (qualified_name
+      (identifier))))
 ==========
 Import with alias
 ==========
@@ -16,8 +17,9 @@ import thing as other_thing
 ---
 (source_file
   (groovy_import
-    (identifier)
-    (identifier)))
+    import: (qualified_name
+      (identifier))
+    import_alias: (identifier)))
 ==========
 Import with dotted ident
 ==========
@@ -25,26 +27,49 @@ import package.subpackage
 
 ---
 (source_file
- (groovy_import
-   (dotted_identifier
-   (identifier)
-   (identifier))))
+  (groovy_import
+    import: (qualified_name
+      (identifier)
+      (identifier))))
 ==========
 Star import
 ==========
 import all_of_the_things.*
+import java.util.*
 
 ---
 (source_file
- (groovy_import
-   (identifier)))
+  (groovy_import
+    import: (qualified_name
+      (identifier))
+    (wildcard_import))
+  (groovy_import
+    import: (qualified_name
+      (identifier)
+      (identifier))
+    (wildcard_import)))
 ==========
 Static import statement
 ==========
 import static thing
+import static groovy.lang.*
+import static Calendar.getInstance as now
 
 ---
 (source_file
   (groovy_import
     (modifier)
-    (identifier)))
+    import: (qualified_name
+      (identifier)))
+  (groovy_import
+    (modifier)
+    import: (qualified_name
+      (identifier)
+      (identifier))
+    (wildcard_import))
+  (groovy_import
+    (modifier)
+    import: (qualified_name
+      (identifier)
+      (identifier))
+    import_alias: (identifier)))

--- a/corpus/package.test
+++ b/corpus/package.test
@@ -6,7 +6,8 @@ package my_package_name
 ---
 (source_file
   (groovy_package
-    (identifier)))
+    (qualified_name
+      (identifier))))
 ==========
 Package with dotted ident
 ==========
@@ -15,6 +16,6 @@ package com.yoursite
 ---
 (source_file
   (groovy_package
-    (dotted_identifier
-    (identifier)
-    (identifier))))
+    (qualified_name
+      (identifier)
+      (identifier))))

--- a/grammar.js
+++ b/grammar.js
@@ -104,18 +104,20 @@ module.exports = grammar({
       $.identifier,
     ),
 
+    _import_name: $ => choice(
+      $.identifier,
+      seq($._import_name, '.', $.identifier)
+    ),
+
     groovy_import: $ => seq(
       'import',
       optional($.modifier),
-      field('import',
-          choice(
-            $.identifier,
-            $.dotted_identifier,
-            seq(choice($.identifier, $.dotted_identifier), '.*')
-          )
-      ),
+      field('import', alias($._import_name, $.qualified_name)),
       optional(
-        seq('as', field('import_alias', $.identifier))
+          choice(
+            seq('.', alias(token.immediate('*'), $.wildcard_import)),
+            seq('as', field('import_alias', $.identifier))
+          ),
       )
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -121,10 +121,7 @@ module.exports = grammar({
       )
     ),
 
-    groovy_package: $ => seq(
-        'package',
-        choice($.identifier, $.dotted_identifier)
-    ),
+    groovy_package: $ => seq('package', alias($._import_name, $.qualified_name)),
 
     _prefix_expression: $ => prec.left(1, choice(
       $.identifier,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -344,6 +344,32 @@
         }
       ]
     },
+    "_import_name": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_import_name"
+            },
+            {
+              "type": "STRING",
+              "value": "."
+            },
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            }
+          ]
+        }
+      ]
+    },
     "groovy_import": {
       "type": "SEQ",
       "members": [
@@ -367,58 +393,58 @@
           "type": "FIELD",
           "name": "import",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "dotted_identifier"
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "identifier"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "dotted_identifier"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "STRING",
-                    "value": ".*"
-                  }
-                ]
-              }
-            ]
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_import_name"
+            },
+            "named": true,
+            "value": "qualified_name"
           }
         },
         {
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
+              "type": "CHOICE",
               "members": [
                 {
-                  "type": "STRING",
-                  "value": "as"
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "."
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "IMMEDIATE_TOKEN",
+                        "content": {
+                          "type": "STRING",
+                          "value": "*"
+                        }
+                      },
+                      "named": true,
+                      "value": "wildcard_import"
+                    }
+                  ]
                 },
                 {
-                  "type": "FIELD",
-                  "name": "import_alias",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  }
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "as"
+                    },
+                    {
+                      "type": "FIELD",
+                      "name": "import_alias",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      }
+                    }
+                  ]
                 }
               ]
             },
@@ -4246,4 +4272,3 @@
   "inline": [],
   "supertypes": []
 }
-

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -463,17 +463,13 @@
           "value": "package"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "dotted_identifier"
-            }
-          ]
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_import_name"
+          },
+          "named": true,
+          "value": "qualified_name"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2500,19 +2500,11 @@
     "named": true,
     "fields": {
       "import": {
-        "multiple": true,
+        "multiple": false,
         "required": true,
         "types": [
           {
-            "type": ".*",
-            "named": false
-          },
-          {
-            "type": "dotted_identifier",
-            "named": true
-          },
-          {
-            "type": "identifier",
+            "type": "qualified_name",
             "named": true
           }
         ]
@@ -2529,11 +2521,15 @@
       }
     },
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
         {
           "type": "modifier",
+          "named": true
+        },
+        {
+          "type": "wildcard_import",
           "named": true
         }
       ]
@@ -3648,6 +3644,21 @@
       "types": [
         {
           "type": "closure",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "qualified_name",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
           "named": true
         }
       ]
@@ -5087,10 +5098,6 @@
     "named": false
   },
   {
-    "type": ".*",
-    "named": false
-  },
-  {
     "type": "..",
     "named": false
   },
@@ -5457,6 +5464,10 @@
   {
     "type": "while",
     "named": false
+  },
+  {
+    "type": "wildcard_import",
+    "named": true
   },
   {
     "type": "{",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2544,11 +2544,7 @@
       "required": true,
       "types": [
         {
-          "type": "dotted_identifier",
-          "named": true
-        },
-        {
-          "type": "identifier",
+          "type": "qualified_name",
           "named": true
         }
       ]

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,9 +13,8 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-typedef uint16_t TSStateId;
-
 #ifndef TREE_SITTER_API_H_
+typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -87,6 +86,11 @@ typedef union {
   } entry;
 } TSParseActionEntry;
 
+typedef struct {
+  int32_t start;
+  int32_t end;
+} TSCharacterRange;
+
 struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
@@ -126,13 +130,38 @@ struct TSLanguage {
   const TSStateId *primary_state_ids;
 };
 
+static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+  uint32_t index = 0;
+  uint32_t size = len - index;
+  while (size > 1) {
+    uint32_t half_size = size / 2;
+    uint32_t mid_index = index + half_size;
+    TSCharacterRange *range = &ranges[mid_index];
+    if (lookahead >= range->start && lookahead <= range->end) {
+      return true;
+    } else if (lookahead > range->end) {
+      index = mid_index;
+    }
+    size -= half_size;
+  }
+  TSCharacterRange *range = &ranges[index];
+  return (lookahead >= range->start && lookahead <= range->end);
+}
+
 /*
  *  Lexer Macros
  */
 
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
+  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -146,6 +175,17 @@ struct TSLanguage {
   {                          \
     state = state_value;     \
     goto next_state;         \
+  }
+
+#define ADVANCE_MAP(...)                                              \
+  {                                                                   \
+    static const uint16_t map[] = { __VA_ARGS__ };                    \
+    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
+      if (map[i] == lookahead) {                                      \
+        state = map[i + 1];                                           \
+        goto next_state;                                              \
+      }                                                               \
+    }                                                                 \
   }
 
 #define SKIP(state_value) \
@@ -166,7 +206,7 @@ struct TSLanguage {
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) id - LARGE_STATE_COUNT
+#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
 
 #define STATE(id) id
 
@@ -176,7 +216,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = state_value            \
+      .state = (state_value)          \
     }                                 \
   }}
 
@@ -184,7 +224,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = state_value,           \
+      .state = (state_value),         \
       .repetition = true              \
     }                                 \
   }}
@@ -197,14 +237,15 @@ struct TSLanguage {
     }                                 \
   }}
 
-#define REDUCE(symbol_val, child_count_val, ...) \
-  {{                                             \
-    .reduce = {                                  \
-      .type = TSParseActionTypeReduce,           \
-      .symbol = symbol_val,                      \
-      .child_count = child_count_val,            \
-      __VA_ARGS__                                \
-    },                                           \
+#define REDUCE(symbol_name, children, precedence, prod_id) \
+  {{                                                       \
+    .reduce = {                                            \
+      .type = TSParseActionTypeReduce,                     \
+      .symbol = symbol_name,                               \
+      .child_count = children,                             \
+      .dynamic_precedence = precedence,                    \
+      .production_id = prod_id                             \
+    },                                                     \
   }}
 
 #define RECOVER()                    \


### PR DESCRIPTION
- Make the import name much more restrictive, this helps avoid conflicts between dotted names and "." before "*" in imports.
- Don't allow aliases with wildcard import, choose one or the other.
- Write more test cases.

I used this docs as a reference: https://www.groovy-lang.org/structure.html

Related:
- https://github.com/nvim-treesitter/nvim-treesitter/pull/6979