### PR TITLE
Parse annotation import underscore

### DIFF
--- a/corpus/structure.test
+++ b/corpus/structure.test
@@ -82,3 +82,20 @@ pipeline {
                           (declaration
                             name: (identifier)
                             value: (identifier)))))))))))))))
+==========
+Jenkins-import underscore
+==========
+@Library('my-library') _
+
+pipeline {
+}
+---
+(source_file
+  (declaration
+    (annotation
+      (identifier)
+      (argument_list
+        (string
+          (string_content)))))
+  (pipeline
+    (closure)))

--- a/grammar.js
+++ b/grammar.js
@@ -287,6 +287,7 @@ module.exports = grammar({
       optional($.access_modifier),
       repeat($.modifier),
       choice(
+        '_',
         seq(
           choice(field('type', $._type), 'def'),
           field('name', $.identifier),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1893,6 +1893,10 @@
           "type": "CHOICE",
           "members": [
             {
+              "type": "STRING",
+              "value": "_"
+            },
+            {
               "type": "SEQ",
               "members": [
                 {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -951,7 +951,7 @@
     "fields": {
       "name": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "identifier",
@@ -5307,6 +5307,10 @@
   },
   {
     "type": "^=",
+    "named": false
+  },
+  {
+    "type": "_",
     "named": false
   },
   {


### PR DESCRIPTION
fixes #20 

I guess this is not a complete solution as it doesn't handle the following, though I've yet to come across it in the wild.

```
@Library('somelib')
import com.mycorp.pipeline.somelib.UsefulClass

pipeline {
}
```