### PR TITLE
Add constructor_declaration, separate interface from class definition and add "this" support for dotted_identifier

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -55,6 +55,7 @@ module.exports = grammar({
         $.groovy_package,
         $.assignment,
         $.class_definition,
+        $.interface_definition,
         $.declaration,
         $.do_while_loop,
         $.for_in_loop,
@@ -62,6 +63,7 @@ module.exports = grammar({
         $.function_call,
         $.function_declaration,
         $.function_definition,
+        $.constructor_declaration,
         $.if_statement,
         $.juxt_function_call,
         // $.pipeline_step_with_block,
@@ -129,7 +131,8 @@ module.exports = grammar({
       $.index,
       $.function_call,
       $.string,
-      $.list
+      $.list,
+      "this"
     )),
 
     annotation: $ => seq(
@@ -207,7 +210,21 @@ module.exports = grammar({
       repeat($.annotation),
       optional($.access_modifier),
       repeat($.modifier),
-      choice('@interface', 'interface', 'class'),
+      choice('class'),
+      field('name', $.identifier),
+      optional(field('generics', $.generic_parameters)),
+      optional(seq(
+        'extends',
+        field('superclass', $._prefix_expression),
+      )),
+      field('body', $.closure),
+    ),
+
+    interface_definition: $ => seq(
+      repeat($.annotation),
+      optional($.access_modifier),
+      repeat($.modifier),
+      choice('@interface', 'interface'),
       field('name', $.identifier),
       optional(field('generics', $.generic_parameters)),
       optional(seq(
@@ -413,6 +430,15 @@ module.exports = grammar({
       optional($.access_modifier),
       repeat($.modifier),
       field('type', choice($._type, 'def')),
+      field('function', $.identifier),
+      field('parameters', $.parameter_list),
+      field('body', $.closure), //TODO: optional return
+    )),
+
+    constructor_declaration: $ => prec(3, seq(
+      repeat($.annotation),
+      optional($.access_modifier),
+      repeat($.modifier),
       field('function', $.identifier),
       field('parameters', $.parameter_list),
       field('body', $.closure), //TODO: optional return

--- a/grammar.js
+++ b/grammar.js
@@ -28,7 +28,7 @@ const list_of = (e) => seq(
 module.exports = grammar({
   name: 'groovy',
 
-  extras: $ => [/\s/, $.comment, $.groovy_doc],
+  // extras: $ => [/\s/, $.comment, $.groovy_doc],
 
   word: $ => $.identifier,
 

--- a/grammar.js
+++ b/grammar.js
@@ -219,6 +219,12 @@ module.exports = grammar({
       optional(seq(
         'extends',
         field('superclass', $._prefix_expression),
+        repeat(seq(',', field('superclass', $._prefix_expression)))
+      )),
+      optional(seq(
+        'implements',
+        field('interface', $._prefix_expression),
+        repeat(seq(',', field('interface', $._prefix_expression)))
       )),
       field('body', $.closure),
     ),
@@ -233,6 +239,7 @@ module.exports = grammar({
       optional(seq(
         'extends',
         field('superclass', $._prefix_expression),
+        repeat(seq(',', field('superclass', $._prefix_expression)))
       )),
       field('body', $.closure),
     ),
@@ -247,6 +254,7 @@ module.exports = grammar({
       optional(seq(
         'extends',
         field('superclass', $._prefix_expression),
+        repeat(seq(',', field('superclass', $._prefix_expression)))
       )),
       field('body', $.closure),
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -50,12 +50,15 @@ module.exports = grammar({
     _statement: $ => prec.left(PREC.STATEMENT, seq(
       optional($.label),
       choice(
+        $.comment,
+        $.groovy_doc,
         $.assertion,
         $.groovy_import,
         $.groovy_package,
         $.assignment,
         $.class_definition,
         $.interface_definition,
+        $.trait_definition,
         $.declaration,
         $.do_while_loop,
         $.for_in_loop,
@@ -225,6 +228,20 @@ module.exports = grammar({
       optional($.access_modifier),
       repeat($.modifier),
       choice('@interface', 'interface'),
+      field('name', $.identifier),
+      optional(field('generics', $.generic_parameters)),
+      optional(seq(
+        'extends',
+        field('superclass', $._prefix_expression),
+      )),
+      field('body', $.closure),
+    ),
+
+    trait_definition: $ => seq(
+      repeat($.annotation),
+      optional($.access_modifier),
+      repeat($.modifier),
+      choice('trait'),
       field('name', $.identifier),
       optional(field('generics', $.generic_parameters)),
       optional(seq(

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "tree-sitter-groovy",
+  "name": "@vokturz/tree-sitter-groovy",
   "version": "0.0.1",
-  "description": "groovy grammar for tree-sitter",
+  "description": "A Tree-sitter Grammar for Groovy, forked from @murtaza64/tree-sitter-groovy. Only for CodeGPT internals",
   "main": "bindings/node",
   "types": "bindings/node",
   "tree-sitter": [


### PR DESCRIPTION
Hey,

Great parser! I’ve made a few simple updates to improve its functionality:

1. In some cases, a class can have an explicit constructor. The previous version was treating this as a function call, resulting in multiple errors.
2. I’ve separated `interface` from `class_definition`, mainly to address my specific use case where I need to distinguish whether something originates from an interface or a class.
3. I’ve added `this` to the `_prefix_expression` array so that attribute access like `this.foo` is handled correctly. Previously, this was causing a parsing error.

If you’re interested, you can review these changes or incorporate them into your project

