### PR TITLE
fix the general -> primary -> parenthesized expression hierarchy

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -333,7 +333,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "_prefix_expression"
+          "name": "_primary_expression"
         },
         {
           "type": "STRING",
@@ -474,71 +474,42 @@
         }
       ]
     },
-    "_prefix_expression": {
-      "type": "PREC_LEFT",
-      "value": 1,
+    "annotation": {
+      "type": "PREC_RIGHT",
+      "value": 0,
       "content": {
-        "type": "CHOICE",
+        "type": "SEQ",
         "members": [
           {
-            "type": "SYMBOL",
-            "name": "identifier"
+            "type": "STRING",
+            "value": "@"
           },
           {
-            "type": "SYMBOL",
-            "name": "dotted_identifier"
+            "type": "ALIAS",
+            "content": {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "PATTERN",
+                "value": "[$_a-zA-Z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u00F8\\u0100-\\uFFFE][$_0-9a-zA-Z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u00F8\\u0100-\\uFFFE]*"
+              }
+            },
+            "named": true,
+            "value": "identifier"
           },
           {
-            "type": "SYMBOL",
-            "name": "index"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "function_call"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "string"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "list"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "argument_list"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           }
         ]
       }
-    },
-    "annotation": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "@"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "IMMEDIATE_TOKEN",
-            "content": {
-              "type": "PATTERN",
-              "value": "[$_a-zA-Z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u00F8\\u0100-\\uFFFE][$_0-9a-zA-Z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u00F8\\u0100-\\uFFFE]*"
-            }
-          },
-          "named": true,
-          "value": "identifier"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "argument_list"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
     },
     "assertion": {
       "type": "SEQ",
@@ -564,7 +535,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_prefix_expression"
+                "name": "_primary_expression"
               },
               {
                 "type": "CHOICE",
@@ -651,7 +622,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_prefix_expression"
+                "name": "_primary_expression"
               },
               {
                 "type": "STRING",
@@ -668,7 +639,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_prefix_expression"
+                "name": "_primary_expression"
               },
               {
                 "type": "STRING",
@@ -689,7 +660,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "_prefix_expression"
+                "name": "_primary_expression"
               }
             ]
           }
@@ -706,7 +677,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "_prefix_expression"
+                "name": "_primary_expression"
               }
             ]
           }
@@ -1551,7 +1522,7 @@
                   "name": "superclass",
                   "content": {
                     "type": "SYMBOL",
-                    "name": "_prefix_expression"
+                    "name": "_primary_expression"
                   }
                 }
               ]
@@ -1976,88 +1947,6 @@
         }
       ]
     },
-    "_expression": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "parenthesized_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "access_op"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "binary_op"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "boolean_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "closure"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "dotted_identifier"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "function_call"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "STRING",
-          "value": "this"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "increment_op"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "index"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "number_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "list"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "map"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "STRING",
-            "value": "null"
-          },
-          "named": true,
-          "value": "null"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "string"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "ternary_op"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "unary_op"
-        }
-      ]
-    },
     "parenthesized_expression": {
       "type": "PREC",
       "value": 2,
@@ -2075,6 +1964,101 @@
           {
             "type": "STRING",
             "value": ")"
+          }
+        ]
+      }
+    },
+    "_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_primary_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "increment_op"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "binary_op"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ternary_op"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "unary_op"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "access_op"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "closure"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "null"
+          },
+          "named": true,
+          "value": "null"
+        }
+      ]
+    },
+    "_primary_expression": {
+      "type": "PREC_LEFT",
+      "value": 1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "parenthesized_expression"
+          },
+          {
+            "type": "STRING",
+            "value": "this"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "number_literal"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "boolean_literal"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "string"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "dotted_identifier"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "function_call"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "identifier"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "index"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "list"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "map"
           }
         ]
       }
@@ -2327,7 +2311,7 @@
             "name": "function",
             "content": {
               "type": "SYMBOL",
-              "name": "_prefix_expression"
+              "name": "_primary_expression"
             }
           },
           {
@@ -2833,7 +2817,7 @@
         "members": [
           {
             "type": "SYMBOL",
-            "name": "_prefix_expression"
+            "name": "_primary_expression"
           },
           {
             "type": "STRING",
@@ -2885,7 +2869,7 @@
       "value": 1,
       "content": {
         "type": "SYMBOL",
-        "name": "_prefix_expression"
+        "name": "_primary_expression"
       }
     },
     "_juxt_argument_list": {
@@ -3942,7 +3926,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "_prefix_expression"
+            "name": "_primary_expression"
           },
           {
             "type": "SYMBOL",
@@ -4217,6 +4201,11 @@
     [
       "_juxt_function_name",
       "_type"
+    ],
+    [
+      "_juxt_function_name",
+      "_type",
+      "_expression"
     ]
   ],
   "precedences": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -191,10 +191,14 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "array_type",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
           "named": true
         },
         {
@@ -219,6 +223,18 @@
         },
         {
           "type": "list",
+          "named": true
+        },
+        {
+          "type": "map",
+          "named": true
+        },
+        {
+          "type": "number_literal",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
           "named": true
         },
         {
@@ -317,7 +333,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "access_op",
@@ -756,6 +772,10 @@
         "required": false,
         "types": [
           {
+            "type": "boolean_literal",
+            "named": true
+          },
+          {
             "type": "dotted_identifier",
             "named": true
           },
@@ -776,8 +796,24 @@
             "named": true
           },
           {
+            "type": "map",
+            "named": true
+          },
+          {
+            "type": "number_literal",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
             "type": "string",
             "named": true
+          },
+          {
+            "type": "this",
+            "named": false
           }
         ]
       }
@@ -992,6 +1028,10 @@
             "named": true
           },
           {
+            "type": "boolean_literal",
+            "named": true
+          },
+          {
             "type": "builtintype",
             "named": true
           },
@@ -1016,8 +1056,24 @@
             "named": true
           },
           {
+            "type": "map",
+            "named": true
+          },
+          {
+            "type": "number_literal",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
             "type": "string",
             "named": true
+          },
+          {
+            "type": "this",
+            "named": false
           },
           {
             "type": "type_with_generics",
@@ -1310,6 +1366,10 @@
       "required": true,
       "types": [
         {
+          "type": "boolean_literal",
+          "named": true
+        },
+        {
           "type": "dotted_identifier",
           "named": true
         },
@@ -1327,6 +1387,18 @@
         },
         {
           "type": "list",
+          "named": true
+        },
+        {
+          "type": "map",
+          "named": true
+        },
+        {
+          "type": "number_literal",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
           "named": true
         },
         {
@@ -2057,6 +2129,10 @@
         "required": true,
         "types": [
           {
+            "type": "boolean_literal",
+            "named": true
+          },
+          {
             "type": "dotted_identifier",
             "named": true
           },
@@ -2077,8 +2153,24 @@
             "named": true
           },
           {
+            "type": "map",
+            "named": true
+          },
+          {
+            "type": "number_literal",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
             "type": "string",
             "named": true
+          },
+          {
+            "type": "this",
+            "named": false
           }
         ]
       }
@@ -2117,6 +2209,10 @@
             "named": true
           },
           {
+            "type": "boolean_literal",
+            "named": true
+          },
+          {
             "type": "builtintype",
             "named": true
           },
@@ -2145,8 +2241,24 @@
             "named": true
           },
           {
+            "type": "map",
+            "named": true
+          },
+          {
+            "type": "number_literal",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
             "type": "string",
             "named": true
+          },
+          {
+            "type": "this",
+            "named": false
           },
           {
             "type": "type_with_generics",
@@ -2217,6 +2329,10 @@
             "named": true
           },
           {
+            "type": "boolean_literal",
+            "named": true
+          },
+          {
             "type": "builtintype",
             "named": true
           },
@@ -2245,8 +2361,24 @@
             "named": true
           },
           {
+            "type": "map",
+            "named": true
+          },
+          {
+            "type": "number_literal",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
             "type": "string",
             "named": true
+          },
+          {
+            "type": "this",
+            "named": false
           },
           {
             "type": "type_with_generics",
@@ -2297,6 +2429,10 @@
             "named": true
           },
           {
+            "type": "boolean_literal",
+            "named": true
+          },
+          {
             "type": "builtintype",
             "named": true
           },
@@ -2321,8 +2457,24 @@
             "named": true
           },
           {
+            "type": "map",
+            "named": true
+          },
+          {
+            "type": "number_literal",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
             "type": "string",
             "named": true
+          },
+          {
+            "type": "this",
+            "named": false
           },
           {
             "type": "type_with_generics",
@@ -2353,10 +2505,14 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "array_type",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
           "named": true
         },
         {
@@ -2381,6 +2537,18 @@
         },
         {
           "type": "list",
+          "named": true
+        },
+        {
+          "type": "map",
+          "named": true
+        },
+        {
+          "type": "number_literal",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
           "named": true
         },
         {
@@ -2856,8 +3024,12 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
+        {
+          "type": "boolean_literal",
+          "named": true
+        },
         {
           "type": "dotted_identifier",
           "named": true
@@ -2879,6 +3051,18 @@
           "named": true
         },
         {
+          "type": "map",
+          "named": true
+        },
+        {
+          "type": "number_literal",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "string",
           "named": true
         }
@@ -2891,7 +3075,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "access_op",
@@ -3062,6 +3246,10 @@
         "required": true,
         "types": [
           {
+            "type": "boolean_literal",
+            "named": true
+          },
+          {
             "type": "dotted_identifier",
             "named": true
           },
@@ -3082,8 +3270,24 @@
             "named": true
           },
           {
+            "type": "map",
+            "named": true
+          },
+          {
+            "type": "number_literal",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
             "type": "string",
             "named": true
+          },
+          {
+            "type": "this",
+            "named": false
           }
         ]
       }
@@ -3338,6 +3542,10 @@
             "named": true
           },
           {
+            "type": "boolean_literal",
+            "named": true
+          },
+          {
             "type": "builtintype",
             "named": true
           },
@@ -3362,8 +3570,24 @@
             "named": true
           },
           {
+            "type": "map",
+            "named": true
+          },
+          {
+            "type": "number_literal",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
             "type": "string",
             "named": true
+          },
+          {
+            "type": "this",
+            "named": false
           },
           {
             "type": "type_with_generics",
@@ -4418,6 +4642,10 @@
           "named": true
         },
         {
+          "type": "boolean_literal",
+          "named": true
+        },
+        {
           "type": "builtintype",
           "named": true
         },
@@ -4443,6 +4671,18 @@
         },
         {
           "type": "list",
+          "named": true
+        },
+        {
+          "type": "map",
+          "named": true
+        },
+        {
+          "type": "number_literal",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
           "named": true
         },
         {

--- a/test/corpus/each.test
+++ b/test/corpus/each.test
@@ -9,11 +9,11 @@ Basic each loop
   (juxt_function_call
     function: (dotted_identifier
       (list
-        (string 
+        (string
           (string_content))
-        (string 
+        (string
           (string_content))
-        (string 
+        (string
           (string_content)))
       (identifier))
     args: (argument_list
@@ -25,3 +25,21 @@ Basic each loop
               (string
                 (string_content))
               (identifier))))))))
+==========
+Each loop on range syntax
+==========
+(1..<5).each{println it}
+---
+(source_file
+  (juxt_function_call
+    function: (dotted_identifier
+      (parenthesized_expression
+        (binary_op
+          (number_literal)
+          (number_literal)))
+      (identifier))
+    args: (argument_list
+      (closure
+        (declaration
+          type: (identifier)
+          name: (identifier))))))


### PR DESCRIPTION
this PR
- renames `_prefix_expression` to `_primary_expression` to match a more common & conventional name
- correctly categorises all primary expression kinds in the grammar as such
- makes `_primary_expression` a child/subkind of `_expression`
- makes `parenthesized_expression` a child of `_primary_expression`

this fixes a class of shortcomings that prevent parsing parenthesised expressions that evaluate to simple objects from being treated as objects everywhere in the grammar.

this addresses the first shortcoming stated in #28
![image](https://github.com/user-attachments/assets/61ae36a4-6e70-4968-aded-2e23e6f04675)
