### PR TITLE
feat: subscripting objects with complex expressions

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -340,8 +340,17 @@
           "value": "."
         },
         {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "parenthesized_expression"
+            }
+          ]
         }
       ]
     },
@@ -1951,19 +1960,33 @@
       "type": "PREC",
       "value": 2,
       "content": {
-        "type": "SEQ",
+        "type": "CHOICE",
         "members": [
           {
-            "type": "STRING",
-            "value": "("
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_expression"
-          },
-          {
-            "type": "STRING",
-            "value": ")"
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "("
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_immediately_invoked_closure"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": ")"
+              }
+            ]
           }
         ]
       }
@@ -2042,10 +2065,6 @@
           },
           {
             "type": "SYMBOL",
-            "name": "function_call"
-          },
-          {
-            "type": "SYMBOL",
             "name": "identifier"
           },
           {
@@ -2059,6 +2078,10 @@
           {
             "type": "SYMBOL",
             "name": "map"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "function_call"
           }
         ]
       }
@@ -2310,17 +2333,8 @@
             "type": "FIELD",
             "name": "function",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_primary_expression"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "closure"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_primary_expression"
             }
           },
           {
@@ -2333,6 +2347,40 @@
           }
         ]
       }
+    },
+    "__immediately_invoked_closure": {
+      "type": "PREC_LEFT",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "function",
+            "content": {
+              "type": "SYMBOL",
+              "name": "closure"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "args",
+            "content": {
+              "type": "SYMBOL",
+              "name": "argument_list"
+            }
+          }
+        ]
+      }
+    },
+    "_immediately_invoked_closure": {
+      "type": "ALIAS",
+      "content": {
+        "type": "SYMBOL",
+        "name": "__immediately_invoked_closure"
+      },
+      "named": true,
+      "value": "function_call"
     },
     "argument_list": {
       "type": "PREC",

--- a/test/corpus/field_access.test
+++ b/test/corpus/field_access.test
@@ -1,0 +1,79 @@
+==========
+Field access with parenthesized expression
+==========
+def plusThree = {it + 3}
+(1..3)
+  .collect(plusThree)
+  .("ea"+"ch"){println it}
+---
+(source_file
+  (declaration
+    name: (identifier)
+    value: (closure
+      (juxt_function_call
+        function: (identifier)
+        args: (argument_list
+          (unary_op
+            (number_literal))))))
+  (juxt_function_call
+    function: (dotted_identifier
+      (function_call
+        function: (dotted_identifier
+          (parenthesized_expression
+            (binary_op
+              (number_literal)
+              (number_literal)))
+          (identifier))
+        args: (argument_list
+          (identifier)))
+      (parenthesized_expression
+        (binary_op
+          (string
+            (string_content))
+          (string
+            (string_content)))))
+    args: (argument_list
+      (closure
+        (declaration
+          type: (identifier)
+          name: (identifier))))))
+==========
+Field access with immediately invoked lambda
+==========
+def plusThree = {it + 3}
+(1..3)
+.collect(plusThree)
+.({ return "each"}()){println it}
+---
+(source_file
+  (declaration
+    name: (identifier)
+    value: (closure
+      (juxt_function_call
+        function: (identifier)
+        args: (argument_list
+          (unary_op
+            (number_literal))))))
+  (juxt_function_call
+    function: (dotted_identifier
+      (function_call
+        function: (dotted_identifier
+          (parenthesized_expression
+            (binary_op
+              (number_literal)
+              (number_literal)))
+          (identifier))
+        args: (argument_list
+          (identifier)))
+      (parenthesized_expression
+        (function_call
+          function: (closure
+            (return
+              (string
+                (string_content))))
+          args: (argument_list))))
+    args: (argument_list
+      (closure
+        (declaration
+          type: (identifier)
+          name: (identifier))))))

--- a/test/corpus/function.test
+++ b/test/corpus/function.test
@@ -169,3 +169,20 @@ Immediately invoked closure
           (string
             (string_content))))
       args: (argument_list))))
+==========
+NOT an immediately invoked closure
+==========
+def friend =
+{return "hysm"}(1..2)
+---
+(source_file
+  (declaration
+    name: (identifier)
+    value: (closure
+      (return
+        (string
+          (string_content)))))
+  (parenthesized_expression
+    (binary_op
+      (number_literal)
+      (number_literal))))


### PR DESCRIPTION
closes #28 and makes parentheses mandatory around immediately invoked closures to match *actual language behaviour*